### PR TITLE
Revert "Fix/DEV-624: Ensures Form nested in the Conditional container is available in the Edit mode."

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -94,17 +94,8 @@
               });
             }
 
-            const formBuilder = container.querySelector('[data-widget-package="com.fliplet.form-builder"]');
-
-            if (formBuilder) {
-              setTimeout(async() => {
-                await Fliplet.Widget.initializeChildren(container, instance);
-                resolve(instance);
-              }, 50);
-            } else {
-              await Fliplet.Widget.initializeChildren(container, instance);
-              resolve(instance);
-            }
+            await Fliplet.Widget.initializeChildren(container, instance);
+            resolve(instance);
 
             return;
           }


### PR DESCRIPTION
Reverts Fliplet/fliplet-widget-conditional-container#22 due to QA fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved intermittent issues where child widgets might not initialise correctly in edit mode.

* **Performance**
  * Streamlined child widget initialisation for more consistent and responsive behaviour in edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->